### PR TITLE
Feature/gulp

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -361,7 +361,7 @@ gulp.task('styles', function(cb){
             })
         ], {
             syntax: syntaxScss
-        })).on('error', notify.onError({ message: 'Error:', title: "Stylehint error"}), notify.logLevel(0))
+        })).on('error', notify.onError({ message: 'Error: <%%= error.message %>', title: "Stylehint error"}), notify.logLevel(0))
         .pipe(sourcemaps.init())
         .pipe(sass({
             includePaths: [
@@ -393,7 +393,7 @@ gulp.task('jshint', function() {
     .pipe(jshint())
     .pipe(jshint.reporter(require('jshint-stylish')))
     .pipe(jshint.reporter('fail'))
-    .on('error', notify.onError({ message: 'Error:', title: "JSHint error"}), notify.logLevel(0));
+    .on('error', notify.onError({ message: 'Error: <%%= error.message %>', title: "JSHint error"}), notify.logLevel(0));
 });
 
 

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -389,7 +389,9 @@ gulp.task('jshint', function() {
         '!' + config.paths.source.js + 'lib/**/*.js'
     ])
     .pipe(jshint())
-    .pipe(jshint.reporter(require('jshint-stylish')));
+    .pipe(jshint.reporter(require('jshint-stylish')))
+    .pipe(jshint.reporter('fail'))
+    .on('error', notify.onError({ message: 'Error:', title: "JSHint error"}), notify.logLevel(0));
 });
 
 

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -25,6 +25,7 @@ var stylelint = require('stylelint');
 var syntaxScss = require("postcss-scss");
 var chalk = require("chalk");
 var notify = require("gulp-notify");
+var reporter = require("postcss-reporter");
 
 
 var handleError = function (error) {
@@ -351,10 +352,14 @@ gulp.task('modernizr:prepare', function(cb) {
 gulp.task('styles', function(cb){
     return gulp.src(config.paths.source.sass + '**/*.scss')
         .pipe(postcss([
-            stylelint()
+            stylelint(),
+            reporter({
+                clearMessages: true,
+                throwError: true
+            })
         ], {
             syntax: syntaxScss
-        }))
+        })).on('error', notify.onError({ message: 'Error:', title: "Stylehint error"}), notify.logLevel(0))
         .pipe(sourcemaps.init())
         .pipe(sass({
             includePaths: [

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -36,6 +36,8 @@ var handleError = function (error) {
         message: lineNumber + 'See console.'
     }).write(error);
 
+    notify.logLevel(0)
+
     // Inspect the error object
     //console.log(error);
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -39,6 +39,8 @@
         "jshint": "~2.9.2",
         "customizr": "https://github.com/Modernizr/customizr.git#5de20c60f68fe6e422fc3177c977f0344eebee54",
         "stylelint": "~5.3.0",
-        "gulp-notify": "~2.2.0"<% } %>
+        "gulp-notify": "~2.2.0",
+        "postcss-reporter": "~1.3.3"
+        <% } %>
     }
 }


### PR DESCRIPTION
Add reporters for JSHint + Stylelint to initiate notify errors.

Please check error messages in notify, I think we should use the global 'handleError' function.
