### PR TITLE
Fixed Grunt stylelint error.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -5,7 +5,8 @@
     "devDependencies": {
         "patternlab-node": "~1.2.0",
         "jshint-stylish": "^2.1.0",
-        "stylelint-config-standard": "~5.0.0",
+        "stylelint": "~6.6.0",
+        "stylelint-config-standard": "~9.0.0",
         "postcss-scss": "~0.1.7",
         "autoprefixer": "~6.3.6",
         "chalk": "~1.1.1",


### PR DESCRIPTION
Add "Stylelint" back to package.json because it was missing from Grunt scaffolding. Also updated "stylelint-config-standard" to the latest version.
