### PR TITLE
Fix error handling for JS errors when transcoding to Babel. 

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -276,6 +276,7 @@ gulp.task('javascript:dev', function() {
         .on('warning', handleError)
         <% if (includeBabel) { %>
         .pipe(babel({ presets: ['es2015'] }))
+        .on('error', handleError)
         .pipe(gulp.dest(config.paths.public.js))
         <% } %>
     ;


### PR DESCRIPTION
Fix error handling for JS errors when transcoding to Babel. Now a error gets thrown instead of breaking the build process.